### PR TITLE
Add PWA support for iPad app deployment

### DIFF
--- a/AhmedReqv2.html
+++ b/AhmedReqv2.html
@@ -4,6 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 <title>Hack4SaferPlates Screens</title>
+<link rel="manifest" href="manifest.json">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="default">
+<link rel="apple-touch-icon" href="screen_one.png">
 <style>
   body, html {
     margin: 0;
@@ -103,6 +107,12 @@
     screen2.classList.remove('active');
     screen1.classList.add('active');
   });
+
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('service-worker.js');
+    });
+  }
 </script>
 
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "Hack4SaferPlates",
+  "short_name": "SaferPlates",
+  "start_url": "AhmedReqv2.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "screen_one.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'hack4saferplates-cache-v1';
+const urlsToCache = [
+  './',
+  './AhmedReqv2.html',
+  './screen_1_NB.jpg',
+  './screen_two.png',
+  './screen_one.png',
+  './button.png',
+  './manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add web app manifest with icon and standalone display
- cache core assets via service worker for offline use
- link manifest and register service worker in HTML for iPad installation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2eb6920c832c96494f9000a94c13