### PR TITLE
Delay screen transition and cache assets for offline use

### DIFF
--- a/AhmedReqv2.html
+++ b/AhmedReqv2.html
@@ -99,13 +99,17 @@
   const screen2 = document.getElementById('screen2');
 
   startBtn.addEventListener('click', () => {
-    screen1.classList.remove('active');
-    screen2.classList.add('active');
+    startBtn.style.pointerEvents = 'none';
+    setTimeout(() => {
+      screen1.classList.remove('active');
+      screen2.classList.add('active');
+    }, 2000);
   });
 
   screen2.addEventListener('dblclick', () => {
     screen2.classList.remove('active');
     screen1.classList.add('active');
+    startBtn.style.pointerEvents = 'auto';
   });
 
   if ('serviceWorker' in navigator) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -13,10 +13,30 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
   );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.map((key) => {
+        if (key !== CACHE_NAME) {
+          return caches.delete(key);
+        }
+      }))
+    )
+  );
+  self.clients.claim();
 });
 
 self.addEventListener('fetch', (event) => {
   event.respondWith(
-    caches.match(event.request).then((response) => response || fetch(event.request))
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request).catch(() => {
+        if (event.request.mode === 'navigate') {
+          return caches.match('./AhmedReqv2.html');
+        }
+      });
+    })
   );
 });


### PR DESCRIPTION
## Summary
- delay switching to second screen for 2 seconds to prevent double taps
- add offline caching with service worker activation and navigation fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd37a69350832c8141586eb3e74b70