### PR TITLE
Enforce 2-second wait before returning to screen one

### DIFF
--- a/AhmedReqv2.html
+++ b/AhmedReqv2.html
@@ -97,19 +97,22 @@
   const startBtn = document.getElementById('startBtn');
   const screen1 = document.getElementById('screen1');
   const screen2 = document.getElementById('screen2');
+  let canGoBack = false;
 
   startBtn.addEventListener('click', () => {
-    startBtn.style.pointerEvents = 'none';
+    screen1.classList.remove('active');
+    screen2.classList.add('active');
+    canGoBack = false;
     setTimeout(() => {
-      screen1.classList.remove('active');
-      screen2.classList.add('active');
+      canGoBack = true;
     }, 2000);
   });
 
   screen2.addEventListener('dblclick', () => {
+    if (!canGoBack) return;
     screen2.classList.remove('active');
     screen1.classList.add('active');
-    startBtn.style.pointerEvents = 'auto';
+    canGoBack = false;
   });
 
   if ('serviceWorker' in navigator) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -13,30 +13,10 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
   );
-  self.skipWaiting();
-});
-
-self.addEventListener('activate', (event) => {
-  event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.map((key) => {
-        if (key !== CACHE_NAME) {
-          return caches.delete(key);
-        }
-      }))
-    )
-  );
-  self.clients.claim();
 });
 
 self.addEventListener('fetch', (event) => {
   event.respondWith(
-    caches.match(event.request).then((response) => {
-      return response || fetch(event.request).catch(() => {
-        if (event.request.mode === 'navigate') {
-          return caches.match('./AhmedReqv2.html');
-        }
-      });
-    })
+    caches.match(event.request).then((response) => response || fetch(event.request))
   );
 });


### PR DESCRIPTION
## Summary
- revert previous delay and caching changes
- block double-tap on screen two for 2 seconds after starting

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd3a66f26c832c95e701fc83468afa